### PR TITLE
allow duplicated metadata

### DIFF
--- a/rflint/rules/duplicates.py
+++ b/rflint/rules/duplicates.py
@@ -43,7 +43,7 @@ class DuplicateSettingsCommon(object):
         for table in suite.tables:
             if table.name == "Settings":
                 check_duplicates(report_duplicate_setting, table,
-                    permitted_dups=["library", "resource", "variables"])
+                    permitted_dups=["library", "resource", "variables", "metadata"])
 
 class DuplicateSettingsInSuite(DuplicateSettingsCommon, SuiteRule):
     pass


### PR DESCRIPTION
Several metadata can exist in resources, hence adding them in permitted_dup